### PR TITLE
Automatically generate ToC.

### DIFF
--- a/doc/FUNCTIONS.md
+++ b/doc/FUNCTIONS.md
@@ -1,4 +1,4 @@
-# ChrysaLisp
+# Functions
 
 ChrysaLisp is built from functions. Ok, so that's just about the most obvious
 thing to say about any computer program but they are organised in a slightly

--- a/doc/LISP.md
+++ b/doc/LISP.md
@@ -1,4 +1,4 @@
-# ChrysaLisp
+# Lisp
 
 It's probably worth a few words specifically about the included Lisp and how it
 works, and how many rules it breaks ! The reason for doing the Lisp was to
@@ -56,7 +56,7 @@ the environment chain is searched to see if a macro exists.
 
 ### Built in symbols
 
-```ChrysaLisp
+```lisp
 &rest
 &optional
 nil
@@ -65,7 +65,7 @@ t
 
 ### Built in functions
 
-```ChrysaLisp
+```lisp
 add
 age
 apply
@@ -165,7 +165,7 @@ write-line
 
 ### boot.lisp symbols
 
-```ChrysaLisp
+```lisp
 min_long
 max_long
 min_int
@@ -182,7 +182,7 @@ fp_frac_mask
 
 ### boot.lisp macros
 
-```ChrysaLisp
+```lisp
 and
 ascii
 compose
@@ -206,7 +206,7 @@ when
 
 ### boot.lisp functions
 
-```ChrysaLisp
+```lisp
 abs
 align
 bit-not
@@ -274,7 +274,7 @@ within-compile-env
 
 ### asm.inc symbols
 
-```ChrysaLisp
+```lisp
 debug_mode
 debug_emit
 debug_inst
@@ -282,7 +282,7 @@ debug_inst
 
 ### asm.inc functions
 
-```ChrysaLisp
+```lisp
 all-vp-files
 compile
 compile-pipe

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -1,4 +1,4 @@
-# ChrysaLisp
+# TODO
 
 In no particular order but to just to ensure I get thoughts down. I'll keep
 adding to this as I go along. If anybody would like to try helping out, then

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,7 @@ release = ''
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.githubpages',
+    'm2r'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -50,9 +51,6 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = ['.rst', '.md']
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
 # The master toctree document.
 master_doc = 'index'
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,9 @@ Welcome to ChrysaLisp's documentation!
    TAOS
    TODO
 
+.. mdinclude:: ../README.md
+
+
 Indices and tables
 ==================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. Building these docs
+   ===
+
+.. pip install --user sphinx recommonmark sphinx_rtd_theme m2r
+   make html
+
 Welcome to ChrysaLisp's documentation!
 ======================================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,10 @@ Welcome to ChrysaLisp's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   LISP
+   FUNCTIONS
+   TAOS
+   TODO
 
 Indices and tables
 ==================

--- a/doc/screen_shot.png
+++ b/doc/screen_shot.png
@@ -1,0 +1,1 @@
+../screen_shot.png


### PR DESCRIPTION
Added a dependency on "m2r". This let's us treat markdown like it's restructuredtext, sphinx's preferred text format. Had our index automatically generate a table of contents from included markdown.

Renamed "index.md" to "index.rst", since sphinx really likes restructured text for some reason...

Included project readme in docs build.