### PR TITLE
Fixed some issues, added new and save

### DIFF
--- a/apps/edit/app.lisp
+++ b/apps/edit/app.lisp
@@ -107,9 +107,11 @@
 			(down)))
 	; ensures behavior resembling other text editors when adjusting cx
 	(set-sticky)
-	(cursor-visible)
+	(bind '(buffer_ox buffer_oy) (cursor-visible))
+	(set slider 'value buffer_oy)
 	(vdu-load vdu buffer_text 0 (get slider 'value) buffer_cx buffer_cy)
-	(vdu-load vdu buffer_text buffer_ox buffer_oy buffer_cx buffer_cy))
+	(vdu-load vdu buffer_text buffer_ox buffer_oy buffer_cx buffer_cy)
+	(view-dirty slider))
 
 (defq current_buffer (open-buffer sample_path))
 (bind '(buffer_path buffer_text buffer_ox buffer_oy buffer_cx buffer_cy) current_buffer)

--- a/apps/edit/app.lisp
+++ b/apps/edit/app.lisp
@@ -2,133 +2,148 @@
 (import 'sys/lisp.inc)
 (import 'class/lisp.inc)
 (import 'gui/lisp.inc)
+(import 'apps/edit/input.inc)
 
 (structure 'event 0
-	(byte 'win_close 'win_min 'win_max))
+	(byte 'win_close 'win_min 'win_max 'win_layout 
+		'win_scroll 'save 'new))
 
-(defq id t vdu_width 60 vdu_height 40 cursor_x 0 cursor_y 0 offset_x 0 offset_y 0 text_buf (list) sticky_x 0)
+;1st attempt at buffer structure.
+(structure 'buffer 0
+	(str 'path) (list 'text) (int 'ox 'oy 'cx 'cy))
+ 
+(defq id t vdu_min_width 40 vdu_min_height 24 vdu_width 60 vdu_height 40 sx 0 buffer_store (list) buf_num 0 tmp_num 0
+	sample_path "apps/edit/app.lisp")
 
-;this will need scrollbars etc to change the text offset in the VDU area
-(ui-tree window (create-window (+ window_flag_close window_flag_min window_flag_max)) ('color 0xc0000000)
-	(ui-element vdu (create-vdu) ('vdu_width vdu_width 'vdu_height vdu_height 'ink_color argb_green
-		'font (create-font "fonts/Hack-Regular.ctf" 16))))
+;vdu doesn't play well with textfields.
+(ui-tree window (create-window (+ window_flag_close window_flag_min window_flag_max)) ('color argb_white)
+	(ui-element _ (create-flow) ('flow_flags (logior flow_flag_down flow_flag_fillw flow_flag_lasth))	
+		(ui-element _ (create-grid) ('grid_width 2 'grid_height 1)
+			(component-connect (ui-element _ (create-button) ('text "New" 'color toolbar_col)) event_new)
+			(component-connect (ui-element _ (create-button) ('text "Save" 'color toolbar_col)) event_save))
+			; (ui-element textfield (create-textfield) ('text "" 'color argb_white))
+			; (ui-element label (create-label)('text "" 'color toolbar_col)))
+		(ui-element _ (create-flow) ('flow_flags (logior flow_flag_left flow_flag_fillh flow_flag_lastw))
+			(component-connect (ui-element slider (create-slider) ('color slider_col)) event_win_scroll)
+			(ui-element vdu (create-vdu) 
+				('vdu_width vdu_width 'vdu_height vdu_height 'min_width vdu_width 'min_height vdu_height
+				'ink_color argb_black 'font (create-font "fonts/Hack-Regular.ctf" 16))))))
 
-(gui-add (apply view-change (cat (list window 32 32)
-	(view-pref-size (window-set-title (window-connect-close (window-connect-min
-		(window-connect-max window event_win_max) event_win_min) event_win_close) "Editor - Test code for now !!!")))))
+(gui-add (apply view-change (cat (list window 48 16)
+	(view-pref-size (window-set-title
+		(component-connect (window-connect-close (window-connect-min
+			(window-connect-max window event_win_max) event_win_min) event_win_close) event_win_layout) 
+				"edit")))))
 
-;load some temp text for now
-(each-line (lambda (_)
-	(push text_buf _)) (file-stream "apps/edit/app.lisp"))
+(defun-bind new-buffer ()
+	(defq path (cat "apps/login/Guest/" "tmp_txt_" (str (setq tmp_num (inc tmp_num))))
+		text (list (join " " (ascii-char 10))) ox 0 oy 0 cx 0 cy 0)
+	(list path text ox oy cx cy))
 
-(defun-bind edit-input (c)
-	;insert at cursor etc. Things like char insert and so forth probably want to be
-	;asbstracted into some text_buf commands that can later be scripted and this would just
-	;become key bindings to call things.
-	;'text_buf offset_x offset_y cursor_x cursor_y' could also be abstracted into a text buffer
-	;object and then we can have multiple text buffers and all that good stuff too.
-	(cond
-		((or (= c 10) (= c 13))
-			;return key
-			(cond
-				((>= cursor_y (length text_buf))
-					;off end of text so just append a blank line
-					(push text_buf "")
-					(setq cursor_y (length text_buf)))
-				(t	;break this line
-					(defq line (elem cursor_y text_buf)
-						line_front (slice 0 (min cursor_x (length line)) line)
-						line_back (slice (min cursor_x (length line)) -1 line))
-					(elem-set cursor_y text_buf line_front)
-					(setq cursor_y (min (inc cursor_y) (length text_buf))
-						text_buf (insert text_buf cursor_y (list line_back)))))
-			(setq cursor_x 0))
-		((= c 0x40000050)
-			;cursor left key
-			(setq cursor_x (max (dec cursor_x) 0))
-      			(setq sticky_x cursor_x))
-		((= c 0x4000004f)
-			;cursor right key
-			(defq line (if (>= cursor_y (length text_buf)) "" (elem cursor_y text_buf)))
-			(setq cursor_x (min (inc cursor_x) (length line)))
-      			(setq sticky_x cursor_x))
-		((= c 0x40000052)
-			;cursor up key
-			(setq cursor_y (max (dec cursor_y) 0))
-      			(setq cursor_x (min sticky_x (length (elem cursor_y text_buf)))))
-		((= c 0x40000051)
-			;cursor down key
-      			(if (= cursor_y (dec (length text_buf)))
-        		(setq cursor_x (length (elem cursor_y text_buf)) sticky_x cursor_x))
-      			(setq cursor_y  (min (inc cursor_y) (dec (length text_buf))))
-      			(setq cursor_x (min sticky_x (length (elem cursor_y text_buf)))))
-		((= c 8)
-			;backspace key
-			(cond
-				((> cursor_x 0)
-				  	(elem-set cursor_y text_buf (erase (elem cursor_y text_buf) (dec cursor_x) cursor_x))
-					(setq cursor_x (dec cursor_x)))
-        			((<= cursor_y 0)
-					(setq cursor_y 0))
-				((<= cursor_x 0)
-					;backspace into previous line
-					(defq prev_line (elem (dec cursor_y) text_buf)
-						cat_line (cat prev_line (elem cursor_y text_buf)))
-					(setq cursor_x (length prev_line) cursor_y (dec cursor_y))
-					(elem-set cursor_y text_buf cat_line)
-					(setq text_buf (erase text_buf (inc cursor_y) (+ cursor_y 2))))))
-		((or (= c 9) (<= 32 c 127))
-			;insert the tab/char at cursor or append to end etc
-			(defq line (if (>= cursor_y (length text_buf)) "" (elem cursor_y text_buf))
-				line (insert line (min cursor_x (length line)) (ascii-char c)))
-			(setq cursor_x (inc cursor_x))
-			(if (>= cursor_y (length text_buf))
-				(push text_buf line)
-				(elem-set cursor_y text_buf line))))
-	;set text offsets to ensure cursor visible, maybe add some margin ?
-	(cond
-		((< cursor_x offset_x)
-			(setq offset_x cursor_x))
-		((>= cursor_x (+ offset_x vdu_width))
-			(setq offset_x (- cursor_x vdu_width -1))))
-	(cond
-		((< cursor_y offset_y)
-			(setq offset_y cursor_y))
-		((>= cursor_y (+ offset_y vdu_height))
-			(setq offset_y (- cursor_y vdu_height -1))))
-  ; ensures behavior resembling other text editors when adjusting cursor_x
-  	(unless (= cursor_y (dec (length text_buf)))
-    		(if (and (> cursor_x sticky_x) (<= sticky_x (length (elem cursor_y text_buf))))
-      			(setq cursor_x sticky_x))
-    		(if (>= cursor_x (length (elem cursor_y text_buf)))
-      			(setq cursor_x (length (elem cursor_y text_buf)))))
-	;load the vdu display
-	(vdu-load vdu text_buf offset_x offset_y cursor_x cursor_y))
+(defun-bind open-buffer (path)
+	;if optional pos, implementor must check if it's a valid position.
+	;(if (not pos) (defq pos '(0 0 0 0)))
+	(defq text (list) ox 0 oy 0 cx 0 cy 0)
+	(each-line (lambda (_) (push text _)) (file-stream path))
+	;(push text (ascii-char 10))
+	; (bind '(_ _ _ _) position)
+	(list path text ox oy cx cy))
 
-(defun-bind vdu-resize (w h)
+;returns -1 if not found or if no buffers are in buffer_store. Otherwise, it returns index.
+(defun-bind find-buffer (path)
+	(defq i 0 ret -1)
+	(unless (= (length buffer_store) 0)
+		(while (<= i (length buffer_store))
+			(if (eql path (elem 0 (elem i buffer_store)))
+				(setq ret i)) (inc i))) ret)
+
+(defun-bind save-buffer ()
+	(save (join buffer_text (ascii-char 10)) buffer_path))
+
+(defun-bind window-resize (w h)
 	(setq vdu_width w vdu_height h)
-	(set vdu 'vdu_width vdu_width 'vdu_height vdu_height)
+	(set vdu 'vdu_width w 'vdu_height h 'min_width w 'min_height h)
 	(bind '(x y _ _) (view-get-bounds window))
 	(bind '(w h) (view-pref-size window))
+	(set vdu 'min_width vdu_min_width 'min_height vdu_min_height)
 	(view-change-dirty window x y w h)
-	(vdu-load vdu text_buf offset_x offset_y cursor_x cursor_y))
+	(vdu-load vdu buffer_text buffer_ox buffer_oy buffer_cx buffer_cy))
 
-(vdu-load vdu text_buf offset_x offset_y cursor_x cursor_y)
+(defun-bind window-layout (w h)
+	(setq vdu_width w vdu_height h)
+	(set vdu 'vdu_width w 'vdu_height h 'min_width w 'min_height h)
+	(bind '(x y _ _) (view-get-bounds vdu))
+	(bind '(w h) (view-pref-size vdu))
+	(set vdu 'min_width vdu_min_width 'min_height vdu_min_height)
+	(view-change vdu x y w h)
+	;set slider values
+	(def slider 'maximum (max 0 (- (length buffer_text) vdu_height)) 'portion vdu_height 'value buffer_oy)
+	(view-dirty slider)
+	(vdu-load vdu buffer_text buffer_ox buffer_oy buffer_cx buffer_cy))
+
+(defun-bind vdu-input (c)
+	;'buffer_text ox oy cx cy' could also be abstracted
+	;into a text buffer object and then we can have multiple text buffers and
+	;all that good stuff too.
+	(cond
+		((or (= c 10) (= c 13))
+			(return)
+			(setq buffer_cx 0))
+		((= c 8)
+			(backspace)
+			(setq sx buffer_cx))
+		((or (= c 9) (<= 32 c 127))
+			(printable c)
+			(setq sx buffer_cx))
+		((= c 0x40000050)
+			(left)
+			(setq sx buffer_cx))
+		((= c 0x4000004f)
+			(right)
+			(setq sx buffer_cx))
+		((= c 0x40000052)
+			(up))
+		((= c 0x40000051)
+			(down)))
+	; ensures behavior resembling other text editors when adjusting cx
+	(set-sticky)
+	(cursor-visible)
+	(vdu-load vdu buffer_text 0 (get slider 'value) buffer_cx buffer_cy)
+	(vdu-load vdu buffer_text buffer_ox buffer_oy buffer_cx buffer_cy))
+
+(defq current_buffer (open-buffer sample_path))
+(bind '(buffer_path buffer_text buffer_ox buffer_oy buffer_cx buffer_cy) current_buffer)
+(window-layout vdu_width vdu_height)
+
 (while id
 	(cond
-		((= (setq id (get-long (defq msg (mail-read (task-mailbox))) ev_msg_target_id)) event_win_close)
+		((= (setq id (get-long (defq msg (mail-read (task-mailbox))) 
+			ev_msg_target_id)) event_win_close)
 			;close button
 			(setq id nil))
+		((= id event_new)
+			(push buffer_store current_buffer)
+			(setq current_buffer (new-buffer))
+			(bind '(buffer_path buffer_text buffer_ox buffer_oy buffer_cx buffer_cy) current_buffer)
+			(window-layout vdu_width vdu_height))
+		((= id event_save)
+			(save-buffer))
+		((= id event_win_layout)
+			;user window resize
+			(apply window-layout (vdu-max-size vdu)))
 		((= id event_win_min)
 			;min button
 			(vdu-resize 60 40))
 		((= id event_win_max)
 			;max button
 			(vdu-resize 120 40))
-		(t	;it's a GUI event
+		((= id event_win_scroll)
+			;user scroll bar
+			(vdu-load vdu buffer_text 0 (get slider 'value) buffer_cx buffer_cy))
+		(t
 			(view-event window msg)
 			(and (= (get-long msg ev_msg_type) ev_type_key)
 				(> (get-int msg ev_msg_key_keycode) 0)
-				(edit-input (get-int msg ev_msg_key_key))))))
+				(vdu-input (get-int msg ev_msg_key_key))))))
 
 (view-hide window)

--- a/apps/edit/app.lisp
+++ b/apps/edit/app.lisp
@@ -144,8 +144,8 @@
 			(vdu-load vdu buffer_text 0 (get slider 'value) buffer_cx buffer_cy))
 		(t
 			(view-event window msg)
-			(and (= (get-long msg ev_msg_type) ev_type_key)
-				(> (get-int msg ev_msg_key_keycode) 0)
+			(if (and (= (get-long msg ev_msg_type) ev_type_key)
+				(> (get-int msg ev_msg_key_keycode) 0))
 				(vdu-input (get-int msg ev_msg_key_key))))))
 
 (view-hide window)

--- a/apps/edit/app.lisp
+++ b/apps/edit/app.lisp
@@ -142,10 +142,12 @@
 		((= id event_win_scroll)
 			;user scroll bar
 			(vdu-load vdu buffer_text 0 (get slider 'value) buffer_cx buffer_cy))
-		(t
+		((= id (component-get-id vdu))
 			(view-event window msg)
-			(if (and (= (get-long msg ev_msg_type) ev_type_key)
-				(> (get-int msg ev_msg_key_keycode) 0))
-				(vdu-input (get-int msg ev_msg_key_key))))))
+			(and (= (get-long msg ev_msg_type) ev_type_key)
+				(> (get-int msg ev_msg_key_keycode) 0)
+				(vdu-input (get-int msg ev_msg_key_key))))
+		(t
+			(view-event window msg))))
 
 (view-hide window)

--- a/apps/edit/input.inc
+++ b/apps/edit/input.inc
@@ -13,7 +13,8 @@
 		((< buffer_cy buffer_oy)
 			(setq buffer_oy buffer_cy))
 		((>= buffer_cy (+ buffer_oy vdu_height))
-			(setq buffer_oy (- buffer_cy vdu_height -1)))))
+			(setq buffer_oy (- buffer_cy vdu_height -1))))
+	(list buffer_ox buffer_oy))
 
 (defun-bind set-sticky ()
 	(defq line (elem buffer_cy buffer_text))

--- a/apps/edit/input.inc
+++ b/apps/edit/input.inc
@@ -1,0 +1,109 @@
+;Visual buffer input
+; TODO: custom margins and line wrap
+;;;;;;;;;;;;;;
+; buffer input
+;;;;;;;;;;;;;;
+(defun-bind cursor-visible ()
+	(cond
+		((< buffer_cx buffer_ox)
+			(setq buffer_ox buffer_cx))
+		((>= buffer_cx (+ buffer_ox vdu_width))
+			(setq buffer_ox (- buffer_cx vdu_width -1))))
+	(cond
+		((< buffer_cy buffer_oy)
+			(setq buffer_oy buffer_cy))
+		((>= buffer_cy (+ buffer_oy vdu_height))
+			(setq buffer_oy (- buffer_cy vdu_height -1)))))
+
+(defun-bind set-sticky ()
+	(defq line (elem buffer_cy buffer_text))
+	(cond
+		((and (> buffer_cx sx) (<= sx (length line)))
+			(setq buffer_cx sx))
+		((>= buffer_cx (length line))
+			(setq buffer_cx (length line)))))
+
+(defun-bind printable (c)
+	;insert the tab/char at cursor or append to end etc
+			(defq line (if (>= buffer_cy (length buffer_text)) "" (elem buffer_cy buffer_text))
+				line (insert line (min buffer_cx (length line)) (ascii-char c)))
+			(setq buffer_cx (inc buffer_cx))
+			(if (>= buffer_cy (length buffer_text))
+				(push buffer_text line)
+				(elem-set buffer_cy buffer_text line)))
+
+(defun-bind return ()
+;return key
+	(cond
+		((>= buffer_cy (length buffer_text))
+			;off end of text so just append a blank line
+			(push buffer_text "")
+			(setq buffer_cy (length buffer_text)))
+		(t	;break this line
+			(defq line (elem buffer_cy buffer_text)
+				line_front (slice 0 (min buffer_cx (length line)) line)
+				line_back (slice (min buffer_cx (length line)) -1 line))
+					(elem-set buffer_cy buffer_text line_front)
+					(setq buffer_cy (min (inc buffer_cy) (length buffer_text))
+						buffer_text (insert buffer_text buffer_cy (list line_back)))))
+	(setq buffer_cx 0))
+
+(defun-bind backspace ()
+	(cond
+		((> buffer_cx 0)
+			(elem-set buffer_cy buffer_text (erase (elem buffer_cy buffer_text)
+				(dec buffer_cx) buffer_cx))
+			(setq buffer_cx (dec buffer_cx)))
+		((<= buffer_cx 0)
+			(unless (<= buffer_cy 0) 
+				;backspace into previous line
+				(defq prev_line (elem (dec buffer_cy) buffer_text)
+					cat_line (cat prev_line (elem buffer_cy buffer_text)))
+				(setq buffer_cx (length prev_line) buffer_cy (dec buffer_cy))
+				(elem-set buffer_cy buffer_text cat_line)
+				(setq buffer_text (erase buffer_text (inc buffer_cy) (+ buffer_cy 2)))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;
+; editor cursor behavior
+;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun-bind left ()
+	(cond
+		((<= buffer_cx 0)
+			(cond
+				((<= buffer_cy 0)
+					(setq buffer_cy 0 buffer_cx 0))
+				((> buffer_cy 0)
+					(setq buffer_cy (dec buffer_cy) buffer_cx (setq buffer_cx 
+						(length (elem buffer_cy buffer_text)))))))
+		((> buffer_cx 0)
+			(setq buffer_cx (dec buffer_cx)))))
+
+(defun-bind right ()
+	(cond
+		((>= buffer_cx (length (elem buffer_cy buffer_text)))
+			(cond
+				((>= buffer_cy (dec (length buffer_text)))
+					(setq buffer_cx (length (elem buffer_cy buffer_text))))
+				((< buffer_cy (dec (length buffer_text)))
+					(setq buffer_cy (inc buffer_cy) buffer_cx (setq buffer_cx 0)))))
+		((< buffer_cx (length (elem buffer_cy buffer_text)))
+			(setq buffer_cx (inc buffer_cx)))))
+
+(defun-bind up ()
+	(cond
+		((<= buffer_cy 0)
+			(setq buffer_cx 0))
+		((> buffer_cy 0)
+			(setq buffer_cy (dec buffer_cy))
+			(setq buffer_cx (min sx (length (elem buffer_cy buffer_text)))))))
+
+(defun-bind down ()
+	(cond
+		((>= buffer_cy (dec (length buffer_text)))
+			(setq buffer_cy (dec (length buffer_text)))
+			(setq buffer_cx (length (elem buffer_cy buffer_text)))
+			(setq sx (length (elem buffer_cy buffer_text))))
+		((< buffer_cy (dec (length buffer_text)))
+			(setq buffer_cy (inc buffer_cy))
+			(setq buffer_cx (min sx (length (elem buffer_cy buffer_text)))))))


### PR DESCRIPTION
I'm sorry it's taken me so long to submit something.

For now, it still starts by opening a sample buffer to demonstrate an open file. but you can open new buffers and it stores previous buffers in a list for now. It would likely be more efficient to store them in a structure, using the paths and streams separately.

I tried to use a buffer structure. I'm not sure that I've done so in a way that is beneficial. I thought about using tuples with the path and the structure, but there are probably better ways of doing it.

I tried adding a textfield until I implement a modal or something of that sort, but I couldn't keep vdu from steeling/sharing focus. It was probably my implementation. 

I added a scrollbar to edit, slightly modifying your terminal code. It needs to go back to cursor x when a key is pressed, and manual movement doesn't adjust the scrollbar quite yet. It's something I can work on. 

The sticky x behavior is pretty universal across text interface. It might be something worth implementing in vdu, int the long run.

 

