### PR TITLE
Fix ASCII space input, add run_fb.sh for framebuffer

### DIFF
--- a/docs/FRAMEBUFFER.md
+++ b/docs/FRAMEBUFFER.md
@@ -9,8 +9,9 @@ Bullseye), you'll first need to download the Raspberry Pi system imager from:
 
 Running the imager will let you select an operating system, storage device and
 target microSD storage card to write to. To install the required 64-bit Linux,
-hit "Choose OS", then "Raspberry Pi OS (other", then "Raspberry Pi OS
-(64-bit))". Click on the Settings icon in the lower right and select "pi.local"
+hit "Choose OS", then "Raspberry Pi OS (other)", then "Raspberry Pi OS (64-bit)"
+or "Raspberry Pi OS Lite (64-bit)" .
+Click on the Settings icon in the lower right and select "pi.local"
 for the hostname, Enable SSH, login username/password and your wireless LAN
 SSID and password.
 
@@ -96,7 +97,7 @@ make GUI=fb install
 To run ChrysaLisp from the text console, use:
 
 ```code
-./run.sh
+./run_fb.sh
 ```
 
 If all the permissions are right, you should see a graphical screen and can

--- a/run_fb.sh
+++ b/run_fb.sh
@@ -1,0 +1,7 @@
+#Start ChrysaLisp on framebuffer
+
+OS=`cat os`
+CPU=`cat cpu`
+ABI=`cat abi`
+
+exec obj/$CPU/$ABI/$OS/main_gui obj/$CPU/$ABI/sys/boot_image -run gui/gui/gui.lisp $2 $3

--- a/src/gui_fb.c
+++ b/src/gui_fb.c
@@ -620,7 +620,7 @@ static uint64_t get_event_timeout(void *data, int timeout)
                     if (c == '\r') c = '\n';
                     event->type = SDL_KEYDOWN;
                     event->key.state = SDL_PRESSED;
-                    if (c <= ' ' & c != '\n' && c != '\b' && c != '\t') {
+                    if (c < ' ' & c != '\n' && c != '\b' && c != '\t') {
                         event->key.keysym.mod = KMOD_CTRL;
                         c += 'a' - 1;
                     }
@@ -703,7 +703,7 @@ uint64_t host_gui_poll_event(SDL_Event *event)
             get_event_timeout(&ev, 0);
         if (ev.type != 0) {
             saved = 1;
-            return 1;
+            return ev.type;
         }
         return 0;
     }
@@ -715,7 +715,7 @@ uint64_t host_gui_poll_event(SDL_Event *event)
     } else {
         get_event_timeout(event, 0);
     }
-    return event->type != 0;
+    return event->type;
 }
 
 uint64_t host_gui_init(Rect *r)
@@ -992,7 +992,7 @@ static int open_keyboard(void)
     new.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT);
     new.c_cflag &= ~(CSIZE | PARENB);
     new.c_cflag |= CS8;
-    new.c_cc[VMIN] = 1;
+    new.c_cc[VMIN] = 1;     /* =1 required for lone ESC key processing */
     new.c_cc[VTIME] = 0;
     tcsetattr(keybd_fd, TCSAFLUSH, &new);
     return keybd_fd;

--- a/src/gui_fb.c
+++ b/src/gui_fb.c
@@ -598,7 +598,7 @@ static uint64_t get_event_timeout(void *data, int timeout)
     fds[0].events = POLLIN;
     fds[1].fd = mouse_fd;
     fds[1].events = POLLIN;
-    if (poll(fds, 2, timeout) >= 0) {
+    if (poll(fds, 2, timeout) > 0) {
         memset(event, 0, sizeof(SDL_Event));
         if (fds[0].revents & POLLIN) {
             int c, n;


### PR DESCRIPTION
Also returns event type for host_gui_pollevent(0).

Use `./run_fb.sh` to start CL on framebuffer.

Update FRAMEBUFFER.md doc.

FYI: I tested CL on 64-bit PI OS Lite, and no difference as far as window event lag. (None ever seen on PI 3).