### PR TITLE
Fix typos in tui powershell commands

### DIFF
--- a/funcs.ps1
+++ b/funcs.ps1
@@ -99,17 +99,17 @@ function boot_cpu_tui
     $cmd = "./obj/$($NHCPU)/$($NHABI)/$($NHOS)/main_tui";
 	if ( $cpu -lt 1 ){
 		if ( $front -eq $FALSE ){
-			Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$(HCPU)/$(HABI)/sys/boot_image $link -run apps/tui/tui.lisp"
+			Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$($HCPU)/$($HABI)/sys/boot_image $link -run apps/tui/tui.lisp"
 		}
 		else {
-			$process = Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$(HCPU)/$(HABI)/sys/boot_image $link -run apps/tui/tui.lisp" -PassThru -Wait
+			$process = Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$($HCPU)/$($HABI)/sys/boot_image $link -run apps/tui/tui.lisp" -PassThru -Wait
 			if ( $process.ExitCode -eq 0){
 				Stop-Process -Name main_tui -Force 2>&1 | out-null
 			}
 		}
 	}
 	else {
-		Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$(HCPU)/$(HABI)/sys/boot_image $link"
+		Start-Process -FilePath $cmd -NoNewWindow -ArgumentList "obj/$($HCPU)/$($HABI)/sys/boot_image $link"
 	}
 }
 

--- a/run_tui.ps1
+++ b/run_tui.ps1
@@ -1,8 +1,17 @@
+$HCPU = "x86_64"
+$HABI = "WIN64"
+$HOS  = "Windows"
+
 $dir = Get-Location
 . "$dir\funcs.ps1"
 
+#################################################
+#
+# start of header
+#
+#################################################
 $use_em = $FALSE;
-$ncpu = 8;
+$ncpu = 10;
 $bcpu = 0;
 $showhelp = $FALSE;
 $front = $FALSE;
@@ -55,11 +64,11 @@ else {
 	    $links=""
 	    for ($lcpu = 0; $lcpu -lt $cpus; $lcpu++)
 	    {
-		    $c1 = zero_pad $cpu
-		    $c2 = zero_pad $lcpu
+		    #$c1 = zero_pad $cpu
+		    #$c2 = zero_pad $lcpu
 
-		    $links += add_link $c1 $c2 $links
+		    $links += add_link $cpu $lcpu $links
 	    }
-	    boot_cpu_tui %front $cpu "$links"
+	    boot_cpu_tui $front $cpu "$links"
     }
 }


### PR DESCRIPTION
Some of the parameters for the run_tui.ps1 script were incorrectly attributed.